### PR TITLE
feat: allow preserving manual PalWorldSettings.ini edits

### DIFF
--- a/.env.palworld.example
+++ b/.env.palworld.example
@@ -47,6 +47,11 @@ LOG_FORMAT=text
 ENABLE_PUBLIC_LOBBY=false
 ADDITIONAL_SERVER_OPTIONS=
 
+# If PalWorldSettings.ini already exists, skip regenerating it from env vars/defaults
+# on startup, so manual edits to the file survive a container restart or recreate.
+# Ignored on first run (when the file does not exist yet).
+DISABLE_GENERATE_SETTINGS=false
+
 # -----------------------------------------------------------------------------
 # Game Configuration
 # -----------------------------------------------------------------------------

--- a/src/managers/settings_generator.py
+++ b/src/managers/settings_generator.py
@@ -4,6 +4,7 @@ Settings generator for Palworld server
 Handles INI file generation from configuration objects
 """
 
+import os
 import re
 from pathlib import Path
 from typing import Dict, Any, Optional
@@ -44,6 +45,18 @@ class SettingsGenerator:
                 settings_file = self.config_dir / "PalWorldSettings.ini"
             else:
                 settings_file = output_path
+
+            if settings_file.exists() and os.environ.get(
+                "DISABLE_GENERATE_SETTINGS", "false"
+            ).lower() == "true":
+                log_server_event(
+                    self.logger,
+                    "config_generate_skip",
+                    "Skipping server settings generation: file already exists and "
+                    "DISABLE_GENERATE_SETTINGS=true",
+                    settings_file=str(settings_file),
+                )
+                return True
 
             self.config_dir.mkdir(parents=True, exist_ok=True)
 

--- a/tests/test_settings_generator.py
+++ b/tests/test_settings_generator.py
@@ -99,6 +99,42 @@ class TestSettingsGenerator:
         assert result is True
         assert (tmp_path / "Engine.ini").exists()
 
+    def test_write_server_settings_disable_flag_ignored_when_file_missing(
+        self, generator, tmp_path
+    ):
+        """DISABLE_GENERATE_SETTINGS is ignored when the settings file does not exist yet."""
+        generator.config_dir = tmp_path
+        with patch.dict("os.environ", {"DISABLE_GENERATE_SETTINGS": "true"}):
+            result = generator.write_server_settings()
+        assert result is True
+        assert (tmp_path / "PalWorldSettings.ini").exists()
+
+    def test_write_server_settings_skipped_when_disabled_and_file_exists(
+        self, generator, tmp_path
+    ):
+        """DISABLE_GENERATE_SETTINGS=true preserves an existing, manually edited file."""
+        generator.config_dir = tmp_path
+        settings_file = tmp_path / "PalWorldSettings.ini"
+        settings_file.write_text("manually edited content", encoding="utf-8")
+
+        with patch.dict("os.environ", {"DISABLE_GENERATE_SETTINGS": "true"}):
+            result = generator.write_server_settings()
+
+        assert result is True
+        assert settings_file.read_text(encoding="utf-8") == "manually edited content"
+
+    def test_write_server_settings_not_skipped_when_flag_false(self, generator, tmp_path):
+        """DISABLE_GENERATE_SETTINGS=false (default) regenerates the file as before."""
+        generator.config_dir = tmp_path
+        settings_file = tmp_path / "PalWorldSettings.ini"
+        settings_file.write_text("manually edited content", encoding="utf-8")
+
+        with patch.dict("os.environ", {"DISABLE_GENERATE_SETTINGS": "false"}):
+            result = generator.write_server_settings()
+
+        assert result is True
+        assert settings_file.read_text(encoding="utf-8") != "manually edited content"
+
 
 class TestSettingsGeneratorEdgeCases:
     """Edge case tests for remaining settings_generator coverage."""


### PR DESCRIPTION
## Summary
- Adds a `DISABLE_GENERATE_SETTINGS` env var. When `PalWorldSettings.ini` already exists and `DISABLE_GENERATE_SETTINGS=true`, `write_server_settings()` skips regeneration so manual edits to the file survive a container restart/recreate.
- The flag is ignored on first run (when the file does not exist yet), so the server still starts with a valid, generated settings file.
- Documented the new variable in `.env.palworld.example`.

## Motivation
Currently `PalWorldSettings.ini` is unconditionally regenerated from env vars + defaults on every startup, silently overwriting any manual edits made directly to the file (e.g. settings not yet exposed as env vars, or quick tweaks without a container recreate). This makes the escape hatch opt-in and explicit, without changing default behavior.

## Test plan
- [x] Added 3 new unit tests in `tests/test_settings_generator.py` covering: flag ignored when file missing, file preserved when flag true and file exists, file regenerated when flag false/absent.
- [x] Full test suite passes (`pytest`, 37/37 unit tests for settings_generator, full suite green).